### PR TITLE
Fix weighted_mean function

### DIFF
--- a/maml_rl/metalearner.py
+++ b/maml_rl/metalearner.py
@@ -49,7 +49,8 @@ class MetaLearner(object):
         log_probs = pi.log_prob(episodes.actions)
         if log_probs.dim() > 2:
             log_probs = torch.sum(log_probs, dim=2)
-        loss = -weighted_mean(log_probs * advantages, weights=episodes.mask)
+        loss = -weighted_mean(log_probs * advantages, dim=1,
+            weights=episodes.mask)
 
         return loss
 
@@ -99,7 +100,7 @@ class MetaLearner(object):
             mask = valid_episodes.mask
             if valid_episodes.actions.dim() > 2:
                 mask = mask.unsqueeze(2)
-            kl = weighted_mean(kl_divergence(pi, old_pi), weights=mask)
+            kl = weighted_mean(kl_divergence(pi, old_pi), dim=1, weights=mask)
             kls.append(kl)
 
         return torch.mean(torch.stack(kls, dim=0))
@@ -144,14 +145,15 @@ class MetaLearner(object):
                     log_ratio = torch.sum(log_ratio, dim=2)
                 ratio = torch.exp(log_ratio)
 
-                loss = -weighted_mean(ratio * advantages,
+                loss = -weighted_mean(ratio * advantages, dim=1,
                     weights=valid_episodes.mask)
                 losses.append(loss)
 
                 mask = valid_episodes.mask
                 if valid_episodes.actions.dim() > 2:
                     mask = mask.unsqueeze(2)
-                kl = weighted_mean(kl_divergence(pi, old_pi), weights=mask)
+                kl = weighted_mean(kl_divergence(pi, old_pi), dim=1,
+                    weights=mask)
                 kls.append(kl)
 
         return (torch.mean(torch.stack(losses, dim=0)),

--- a/maml_rl/utils/test/test_torch_utils.py
+++ b/maml_rl/utils/test/test_torch_utils.py
@@ -1,0 +1,54 @@
+import pytest
+
+import numpy as np
+import torch
+
+from maml_rl.utils.torch_utils import weighted_mean, weighted_normalize
+
+def test_weighted_mean_no_dim():
+    lengths = [2, 3, 5, 7, 11]
+    # Inputs
+    inputs_np = np.random.rand(5, 13).astype(np.float32)
+    weights_np = np.zeros((5, 13), dtype=np.float32)
+    for i, length in enumerate(lengths):
+        inputs_np[i, length:] = 0.
+        weights_np[i, :length] = 1.
+    # Pytorch
+    inputs_th = torch.from_numpy(inputs_np)
+    weights_th = torch.from_numpy(weights_np)
+    mean_th = weighted_mean(inputs_th, dim=None, weights=weights_th)
+    # Numpy
+    sum_np, num_np = 0., 0.
+    for i in range(5):
+        for j in range(13):
+            sum_np += inputs_np[i, j] * weights_np[i, j]
+            num_np += weights_np[i, j]
+    mean_np = sum_np / num_np
+
+    assert mean_th.dim() == 0
+    assert np.allclose(mean_th.item(), mean_np)
+
+def test_weighted_mean_dim():
+    lengths = [2, 3, 5, 7, 11]
+    # Inputs
+    inputs_np = np.random.rand(5, 13).astype(np.float32)
+    weights_np = np.zeros((5, 13), dtype=np.float32)
+    for i, length in enumerate(lengths):
+        inputs_np[i, length:] = 0.
+        weights_np[i, :length] = 1.
+    # Pytorch
+    inputs_th = torch.from_numpy(inputs_np)
+    weights_th = torch.from_numpy(weights_np)
+    mean_th = weighted_mean(inputs_th, dim=1, weights=weights_th)
+    # Numpy
+    sum_np = np.zeros((5,), dtype=np.float32)
+    for i in range(5):
+        num_np = 0.
+        for j in range(13):
+            sum_np[i] += inputs_np[i, j] * weights_np[i, j]
+            num_np += weights_np[i, j]
+        sum_np[i] /= num_np
+    mean_np = np.mean(sum_np)
+
+    assert mean_th.dim() == 0
+    assert np.allclose(mean_th.item(), mean_np)

--- a/maml_rl/utils/torch_utils.py
+++ b/maml_rl/utils/torch_utils.py
@@ -3,18 +3,22 @@ from torch.distributions import Categorical, Normal
 
 def weighted_mean(tensor, dim=None, weights=None):
     if weights is None:
-        return torch.mean(tensor)
+        out = torch.mean(tensor)
     if dim is None:
-        sum_weights = torch.sum(weights)
-        return torch.sum(tensor * weights) / sum_weights
-    if isinstance(dim, int):
-        dim = (dim,)
-    numerator = tensor * weights
-    denominator = weights
-    for dimension in dim:
-        numerator = torch.sum(numerator, dimension, keepdim=True)
-        denominator = torch.sum(denominator, dimension, keepdim=True)
-    return numerator / denominator
+        out = torch.sum(tensor * weights)
+        out.div_(torch.sum(weights))
+    else:
+        mean_dim = torch.sum(tensor * weights, dim=dim)
+        mean_dim.div_(torch.sum(weights, dim=dim))
+        out = torch.mean(mean_dim)
+    return out
+
+def weighted_normalize(tensor, dim=None, weights=None, epsilon=1e-8):
+    mean = weighted_mean(tensor, dim=dim, weights=weights)
+    out = tensor * weights - mean
+    std = torch.sqrt(weighted_mean(out ** 2, dim=dim, weights=weights))
+    out.div_(std + epsilon)
+    return out
 
 def detach_distribution(pi):
     if isinstance(pi, Categorical):
@@ -25,11 +29,3 @@ def detach_distribution(pi):
         raise NotImplementedError('Only `Categorical` and `Normal` '
                                   'policies are valid policies.')
     return distribution
-
-def weighted_normalize(tensor, dim=None, weights=None, epsilon=1e-8):
-    if weights is None:
-        weights = torch.ones_like(tensor)
-    mean = weighted_mean(tensor, dim=dim, weights=weights)
-    centered = tensor * weights - mean
-    std = torch.sqrt(weighted_mean(centered ** 2, dim=dim, weights=weights))
-    return centered / (std + epsilon)


### PR DESCRIPTION
 - Fix `weighted_mean` function: take the mean over weighted means in a given dimension, instead of taking the overall weighted mean.
 - Add `dim=1` argument to `weighted_mean` in `MetaLearner`